### PR TITLE
fix: fixed `t_Co is invalid option` issue

### DIFF
--- a/colors/deus.vim
+++ b/colors/deus.vim
@@ -141,12 +141,18 @@ local navyblue = {'#6699CC', 63,  'blue'}
 
 ```lua
 	<highlight group name> = {
-		bg=<color>, -- The color for the background, `NONE`, `FG` or `BG`
-		fg=<color>, -- The color for the foreground, `NONE`, `FG` or `BG`
-		blend=<integer> -- The |highlight-blend| value, if one is desired.
+		-- The color for the background, `NONE`, `FG` or `BG`
+		bg = <color>,
+
+		-- The color for the foreground, `NONE`, `FG` or `BG`
+		fg = <color>
+
+		-- The |highlight-blend| value, if one is desired.
+		[, blend = <integer>]
+
 		-- Style can be 'bold', 'italic', and more. See |attr-list| for more information.
 		-- It can also have a color, and/or multiple <cterm>s.
-		style=<cterm>|{<cterm> [, <cterm>] [color=<color>]})
+		[, style = <cterm>|{<cterm> (, <cterm>) [color=<color>]} ]
 	}
 ```
 
@@ -209,6 +215,27 @@ local navyblue = {'#6699CC', 63,  'blue'}
 	shouldn't remove any if you want a working colorscheme. Most of them are
 	described under |highlight-default|, some from |group-name|, and others from
 	common syntax groups.  Both help sections are good reads.
+	____________________________________________________________________________
+
+	If you want to inherit a specific attribute of another highlight group, you
+	can do the following:
+
+```lua
+	SpellBad = function(self)
+		local inherited_style = self.SpellRare.style
+		inherited_style.color = red
+
+		return {
+			bg=NONE,
+			fg=NONE,
+			style=inherited_style
+		}
+	end
+```
+
+	The function will be executed by |deus| and transformed into the
+	expected result.
+	____________________________________________________________________________
 
 	NOTE: |Replace-mode| will probably be useful here.
 
@@ -221,12 +248,10 @@ local navyblue = {'#6699CC', 63,  'blue'}
 	      the benefits of using this template.
 ]]
 
---[[ DO NOT EDIT `BG`, `FG`, or `NONE`.
-	Feel free to uncomment `BG` and `NONE`. They are not used by default so they are commented out.
-]]
--- local BG   = 'bg'
-local FG   = 'fg'
--- local NONE = 'NONE'
+--[[ DO NOT EDIT `BG` NOR `FG`. ]]
+local BG = 'bg'
+local FG = 'fg'
+local NONE = {}
 
 --[[ These are the ones you should edit. ]]
 -- This is the only highlight that must be defined separately.
@@ -314,7 +339,7 @@ local highlight_groups = {
 	Title       = {fg=dslight3},
 
 	--[[ 4.2.3. Conditional Line Highlighting]]
-	--Conceal={}
+	Conceal = 'NonText',
 	CursorLine      = {bg=gray_darker},
 	CursorLineNr    = {bg=gray_darker, fg=dslight1},
 	debugBreakpoint = 'ErrorMsg',
@@ -428,23 +453,58 @@ local highlight_groups = {
 	csUnspecifiedStatement = 'Statement',
 	csXmlTag     = 'Define',
 	csXmlTagName = 'Define',
+	csQuote = 'Delimiter',
+	razorCode = 'PreProc',
+	razorcsLHSMemberAccessOperator = 'Noise',
+	razorcsRHSMemberAccessOperator = 'razorcsLHSMemberAccessOperator',
+	razorcsStringDelimiter = 'razorhtmlValueDelimiter',
+	razorcsTypeNullable = 'Special',
+	razorcsUnaryOperatorKeyword = 'Operator',
+	razorDelimiter = 'Delimiter',
+	razorEventAttribute = 'PreCondit',
+	razorFor  = 'razorIf',
+	razorhtmlAttribute = 'htmlArg',
+	razorhtmlAttributeOperator = 'Operator',
+	razorhtmlTag = 'htmlTag',
+	razorhtmlValueDelimiter = 'Delimiter',
+	razorIf  = 'PreCondit',
+	razorImplicitExpression = 'PreProc',
+	razorLine = 'Constant',
+	razorUsing = 'Include',
 
 	--[[ 4.3.4. CSS ]]
 	cssBraces     = 'Delimiter',
-	cssProp       = 'Keyword',
+	cssProp       = 'Label',
 	cssSelectorOp = 'Operator',
-	cssTagName    = 'Type',
-	cssTagName    = 'htmlTagName',
+	cssTagName    = 'Structure',
 	scssAmpersand = 'Special',
-	scssAttribute = 'Label',
+	scssAttribute = 'Noise',
 	scssBoolean   = 'Boolean',
 	scssDefault   = 'Keyword',
-	scssElse      = 'PreCondit',
-	scssIf        = 'PreCondit',
-	scssInclude   = 'Include',
-	scssSelectorChar = 'Operator',
-	scssSelectorName = 'Identifier',
-	scssVariable  = 'Define',
+	scssElse      = 'scssIf',
+	scssMixinName      = function(self)
+		local super = self.cssClassName
+		return {bg=super.bg, fg=super.fg, style='Italic'}
+	end,
+	scssIf                 = 'PreCondit',
+	scssInclude            = 'Include',
+	cssClassName           = 'Identifier',
+	cssClassNameDot        = 'Noise',
+	cssFlexibleBoxAttr     = 'cssAttr',
+	cssFunctionComma       = 'Noise',
+	cssImportant           = 'Exception',
+	cssNoise               = 'Noise',
+	cssPseudoClass         = 'Special',
+	cssPseudoClassId       = 'cssSelectorOp',
+	cssUnitDecorators      = 'Type',
+	cssAtRule              = 'PreCondit',
+	cssAttr                = 'Keyword',
+	cssAttrComma           = 'Noise',
+	cssAttrRegion          = 'Keyword',
+	scssSelectorChar       = 'Delimiter',
+	scssDefinition         = 'PreProc',
+	scssSelectorName       = 'Identifier',
+	scssVariable           = 'Define',
 	scssVariableAssignment = 'Operator',
 
 	--[[ 4.3.5. Dart ]]
@@ -464,7 +524,7 @@ local highlight_groups = {
 	goFormatSpecifier       = 'Character',
 	goFunction              = 'Function',
 	goFunctionCall          = 'goFunction',
-	goFunctionReturn        = {},
+	goFunctionReturn        = NONE,
 	goMethodCall            = 'goFunctionCall',
 	goParamType             = 'goReceiverType',
 	goPointerOperator       = 'SpecialChar',
@@ -506,6 +566,7 @@ local highlight_groups = {
 
 	--[[ 4.3.11. JSON ]]
 	jsonBraces = 'luaBraces',
+	jsonEscape = 'SpecialChar',
 	jsonKeywordMatch = 'Operator',
 	jsonNull   = 'Constant',
 	jsonQuote  = 'Delimiter',
@@ -525,10 +586,15 @@ local highlight_groups = {
 	luaFuncParens   = 'Delimiter',
 	luaFuncTable    = 'Structure',
 	luaLocal        = 'Type',
-	luaNoise        = 'Operator',
-	luaParens       = 'Delimiter',
-	luaSpecialTable = 'StorageClass',
+	luaNoise  = 'Delimiter',
+	luaParens = 'Delimiter',
+	luaSpecialTable = 'Structure',
 	luaSpecialValue = 'Function',
+	luaIn     = 'luaRepeat',
+	luaStringLongTag = function(self)
+		local delimiter = self.Delimiter
+		return {bg=delimiter.bg, fg=delimiter.fg, style='italic'}
+	end,
 
 	--[[ 4.3.12. Make ]]
 	makeCommands   = 'Statment',
@@ -541,15 +607,16 @@ local highlight_groups = {
 	markdownH4          = {fg=green_dark, style='bold'},
 	markdownH5          = {fg=cyan, style='bold'},
 	markdownH6          = {fg=purple_light, style='bold'},
-	mkdBold             = 'SpecialComment',
+	mkdBold             = 'Ignore',
 	mkdCode             = 'Keyword',
 	mkdCodeDelimiter    = 'mkdBold',
 	mkdCodeStart        = 'mkdCodeDelimiter',
 	mkdCodeEnd          = 'mkdCodeStart',
 	mkdHeading          = 'Delimiter',
 	mkdItalic           = 'mkdBold',
+	mkdLineBreak        = 'NonText',
 	mkdListItem         = 'Special',
-	mkdRule             = 'Underlined',
+	mkdRule = function(self) return {fg=self.Ignore.fg, style={'underline', color=self.Delimiter.fg}} end,
 	texMathMatcher      = 'Number',
 	texMathZoneX        = 'Number',
 	texMathZoneY        = 'Number',
@@ -607,7 +674,9 @@ local highlight_groups = {
 	--[[ 4.3.26. TOML ]]
 	tomlComment = 'Comment',
 	tomlKey     = 'Label',
-	tomlTable   = 'StorageClass',
+	tomlTable   = 'Structure',
+	tomlDate  = 'Special',
+	tomlFloat = 'Float',
 
 	--[[ 4.3.27. VimScript ]]
 	helpSpecial    = 'Special',
@@ -618,7 +687,7 @@ local highlight_groups = {
 	vimHiGui       = 'vimHiCterm',
 	vimHiGuiFgBg   = 'vimHiGui',
 	vimHiKeyList   = 'Operator',
-	vimOption      = 'Define',
+	vimIsCommand   = 'Identifier',
 	vimSetEqual    = 'Operator',
 	vimNotation    = 'Operator',
 	vimBracket     = 'Define',
@@ -627,6 +696,13 @@ local highlight_groups = {
 	vimSetSep      = 'Constant',
 	vimSep         = 'Constant',
 	vimContinue    = 'Constant',
+	vimCmdSep      = 'Delimiter',
+	vimFunction    = 'Function',
+	vimSetSep      = 'Delimiter',
+	vimUserFunc    = 'vimFunction',
+	vimOption      = 'Keyword',
+	vimScriptDelim = 'Ignore',
+	vimSet         = 'String',
 
 	--[[ 4.3.28. XML ]]
 	xmlAttrib  = 'htmlArg',
@@ -644,6 +720,7 @@ local highlight_groups = {
 
 	--[[ 4.3.30. dos INI ]]
 	dosiniHeader = 'Title',
+	dosiniLabel  = 'Label',
 
 	--[[ 4.3.31. Crontab ]]
 	crontabDay  = 'StorageClass',
@@ -653,7 +730,73 @@ local highlight_groups = {
 	crontabMnth = 'Structure',
 
 	--[[ 4.3.32. PlantUML ]]
-	plantumlColonLine = {},
+	plantumlArrowLR   = 'Statement',
+	plantumlColonLine = NONE,
+	plantumlMindmap   = 'Label',
+	plantumlMindmap2  = 'Label',
+
+	--[[ 4.3.33. YAML ]]
+	yamlKey = 'Label',
+
+	--[[ 4.3.34. Git ]]
+	diffAdded = 'DiffAdd',
+	diffRemoved = 'DiffDelete',
+	gitcommitHeader = 'SpecialComment',
+	gitcommitDiscardedFile = 'gitcommitSelectedFile',
+	gitcommitOverFlow = 'Error',
+	gitcommitSelectedFile = 'Directory',
+	gitcommitSummary  = 'Title',
+	gitcommitUntrackedFile = 'gitcommitSelectedFile',
+	gitconfigAssignment = 'String',
+	gitconfigEscape = 'SpecialChar',
+	gitconfigNone  = 'Operator',
+	gitconfigSection = 'Structure',
+	gitconfigVariable = 'Label',
+	gitrebaseBreak = 'Keyword',
+	gitrebaseCommit = 'Tag',
+	gitrebaseDrop = 'Exception',
+	gitrebaseEdit = 'Define',
+	gitrebaseExec = 'PreProc',
+	gitrebaseFixup = 'gitrebaseSquash',
+	gitrebaseMerge = 'PreProc',
+	gitrebasePick  = 'Include',
+	gitrebaseReset = 'gitrebaseLabel',
+	gitrebaseReword  = 'gitrebasePick',
+	gitrebaseSquash  = 'Macro',
+	gitrebaseSummary = 'Title',
+
+	--[[ 4.3.35. Vimtex ]]
+	texMathRegion = 'Number',
+	texMathSub   = 'Number',
+	texMathSuper = 'Number',
+	texMathRegionX  = 'Number',
+	texMathRegionXX = 'Number',
+
+	--[[ 4.3.36. Coq ]]
+	coqConstructor   = 'Constant',
+	coqDefBinderType = 'coqDefType',
+	coqDefContents1  = 'coqConstructor',
+	coqDefType  = 'Typedef',
+	coqIndBinderTerm  = 'coqDefBinderType',
+	coqIndConstructor = 'Delimiter',
+	coqIndTerm = 'Type',
+	coqKwd = 'Keyword',
+	coqKwdParen   = 'Function',
+	coqProofDelim = 'coqVernacCmd',
+	coqProofDot   = 'coqTermPunctuation',
+	coqProofPunctuation = 'coqTermPunctuation',
+	coqRequire = 'Include',
+	coqTactic  = 'Operator',
+	coqTermPunctuation = 'Delimiter',
+	coqVernacCmd = 'Statement',
+	coqVernacPunctuation = 'coqTermPunctuation',
+
+	--[[ 4.3.37 Help ]]
+	helpHeader = 'Label',
+	helpOption = 'Keyword',
+	helpHeadline = 'Title',
+	helpSectionDelim = 'Delimiter',
+	helpHyperTextJump = 'Underlined',
 
 	--[[ 4.4. Plugins
 		Everything in this section is OPTIONAL. Feel free to remove everything
@@ -665,14 +808,14 @@ local highlight_groups = {
 	ALEWarningSign = 'WarningMsg',
 
 	--[[ 4.4.2. coc.nvim ]]
-	CocErrorHighlight   = {style={'undercurl', color='red'}},
-	CocHintHighlight    = {style={'undercurl', color='magenta'}},
-	CocInfoHighlight    = {style={'undercurl', color='pink_light'}},
-	CocWarningHighlight = {style={'undercurl', color='orange'}},
-	CocErrorSign   = 'ALEErrorSign',
-	CocHintSign    = 'HintMsg',
-	CocInfoSign    = 'InfoMsg',
-	CocWarningSign = 'ALEWarningSign',
+	CocErrorHighlight   = {style={'undercurl', color=red}},
+	CocHintHighlight    = {style={'undercurl', color=magenta}},
+	CocInfoHighlight    = {style={'undercurl', color=pink_light}},
+	CocWarningHighlight = {style={'undercurl', color=orange}},
+	CocErrorSign        = 'ALEErrorSign',
+	CocHintSign         = 'HintMsg',
+	CocInfoSign         = 'InfoMsg',
+	CocWarningSign      = 'ALEWarningSign',
 
 	--[[ 4.4.2. vim-jumpmotion / vim-easymotion ]]
 	EasyMotion = 'IncSearch',
@@ -691,7 +834,7 @@ local highlight_groups = {
 
 	--[[ 4.4.5. vim-indent-guides ]]
 	IndentGuidesOdd  = {bg=gray_darker},
-	IndentGuidesEven = {bg=gray_dark},
+	IndentGuidesEven = {bg=gray},
 
 	--[[ 4.4.7. NERDTree ]]
 	NERDTreeCWD = 'Label',
@@ -712,27 +855,44 @@ local highlight_groups = {
 	TSURI = 'Tag',
 	TSVariableBuiltin = 'Identifier',
 
-  -- [[ barbar.nvim ]]
-  BufferCurrent        = {fg=dslight1,    bg=dsdark0},
-  BufferCurrentMod     = {fg=orange,      bg=dsdark0},
-  BufferCurrentSign    = {fg=dslight3,    bg=dsdark0},
-  BufferCurrentTarget  = {fg=red,         bg=dsdark0, style=bold},
-  BufferVisible        = {fg=dslight3,    bg=dsdark0},
-  BufferVisibleMod     = {fg=orange,      bg=dsdark0},
-  BufferVisibleSign    = {fg=dslight3,    bg=dsdark0},
-  BufferVisibleTarget  = {fg=red,         bg=dsdark0, style=bold},
-  BufferInactive       = {fg=dslight4,    bg=dsdark3},
-  BufferInactiveMod    = {fg=orange,      bg=dsdark3},
-  BufferInactiveSign   = {fg=gray_darker, bg=dsdark3},
-  BufferInactiveTarget = {fg=red,         bg=dsdark3},
-  BufferTabpages       = {fg=dslight1,    bg=dsdark0, style=bold},
-  BufferTabpageFill    = {fg=green_line,  bg=dsdark0},
+	--[[ 4.4.9. barbar.nvim ]]
+	BufferCurrent       = 'TabLineSel',
+	BufferCurrentIndex  = function(self) return {fg=self.InfoMsg.fg, bg=self.BufferCurrent.bg} end,
+	BufferCurrentMod    = {fg=tan, bg=black, style='bold'},
+	BufferCurrentSign   = 'HintMsg',
+	BufferCurrentTarget = 'BufferCurrentSign',
 
-  -- [[ dashboard-nvim ]]
-  dashboardFooter ={fg=dslight3},
-  dashboardHeader = {fg=yellow},
-  dashboardCenter = {fg=dslight1},
-  dashboardShortCut = {fg=dslight4},
+	BufferInactive       = 'BufferVisible',
+	BufferInactiveIndex  = function(self) return {fg=self.InfoMsg.fg, bg=self.BufferInactive.bg} end,
+	BufferInactiveMod    = 'BufferVisibleMod',
+	BufferInactiveSign   = 'BufferVisibleSign',
+	BufferInactiveTarget = 'BufferVisibleTarget',
+
+	BufferTabpages    = {fg=BG, bg=FG, style='bold'},
+	BufferTabpageFill = 'TabLineFill',
+
+	BufferVisible       = 'TabLine',
+	BufferVisibleIndex  = function(self) return {fg=self.InfoMsg.fg, bg=self.BufferVisible.bg} end,
+	BufferVisibleMod    = {fg=white, bg=gray_darker, style='italic'},
+	BufferVisibleSign   = 'BufferVisible',
+	BufferVisibleTarget = function(self)
+		local super = self.BufferVisibleMod
+		return {fg=super.fg, bg=super.bg, style='bold'}
+	end,
+
+	--[[ 4.4.10. vim-sandwhich ]]
+	OperatorSandwichChange = 'DiffText',
+
+	--[[ 4.4.11. Fern ]]
+	FernBranchText = 'Directory',
+
+	--[[ 4.4.12. LSPSaga ]]
+	DefinitionCount = 'Number',
+	DefinitionIcon = 'Special',
+	ReferencesCount = 'Number',
+	ReferencesIcon = 'DefinitionIcon',
+	TargetFileName = 'Directory',
+	TargetWord = 'Title',
 }
 
 --[[ Step 5: Terminal Colors
@@ -771,6 +931,24 @@ local highlight_groups = {
 	this will inevitably cause usability issues so… be careful.
 ]]
 
+local terminal_ansi_colors = {
+	[1]  = black,
+	[2]  = red_dark,
+	[3]  = green_dark,
+	[4]  = orange,
+	[5]  = blue,
+	[6]  = magenta_dark,
+	[7]  = teal,
+	[8]  = gray,
+	[9]  = gray_dark,
+	[10] = red,
+	[11] = green,
+	[12] = yellow,
+	[13] = turqoise,
+	[14] = purple,
+	[15] = cyan,
+	[16] = gray_light
+}
 
 --[[ Step 5: Sourcing
 	When you wish to load your colorscheme, simply add this folder with a plugin manager
@@ -832,10 +1010,10 @@ local highlight_groups = {
 		is correctly set up if they want to enjoy the best possible experience.
 ]]
 
--- Change 'deus' to the name of your colorscheme as defined in step 1.
-require('deus')(
+require(vim.g.colors_name)(
 	highlight_group_normal,
-	highlight_groups
+	highlight_groups,
+	terminal_ansi_colors
 )
 
 -- Thanks to Romain Lafourcade (https://github.com/romainl) for the original template (romainl/vim-rnb).

--- a/lua/deus.lua
+++ b/lua/deus.lua
@@ -1,99 +1,148 @@
 --[[ NOTHING INSIDE THIS FILE NEEDS TO BE EDITED BY THE USER. ]]
+
+--[[
+	/*
+	 * IMPORTS
+	 */
+--]]
+
 local vim = vim
+local api = vim.api
+local exe = api.nvim_command
+local fn  = vim.fn
+local go = vim.go
 
--- Clear the highlighting.
-vim.cmd('hi clear')
-
--- Disable automatic coloring for the IndentGuides plugin.
-vim.g.indent_guides_auto_colors = 0
-
--- If the syntax has been enabled, reset it.
-if vim.fn.exists('syntax_on') then vim.cmd('syntax reset') end
-
--- Determine which set of colors to use.
-local using_hex_or_256 = tonumber(vim.o.t_Co) >= 256
-	or vim.o.termguicolors
-	or vim.fn.has('gui_running')
-	or string.find(vim.fn.expand('$TERM'), '256')
-
--- If we aren't using the hex and 256 colorset, then set the &t_Co variable to 16.
-if not using_hex_or_256 then vim.o.t_Co = 16 end
+--[[
+	/*
+	 * VARS
+	 */
+--]]
 
 -- These are constants for the indexes in the colors that were defined before.
-local PALETTE_ANSI = 3
-local PALETTE_256  = 2
-local PALETTE_HEX  = 1
-local NONE = "NONE"
+local _NONE = 'NONE'
+local _PALETTE_256  = 2
+local _PALETTE_ANSI = 3
+local _PALETTE_HEX  = 1
+local _TYPE_STRING = 'string'
+local _TYPE_TABLE  = 'table'
 
--- Get the color value of a color variable, or "NONE" as a default.
-local function get(color, index) -- {{{ †
-	if type(color) == 'table' and color[index] then
-		return color[index]
-	elseif type(color) == 'string' then
-		return color
-	else
-		return NONE
-	end
-end --}}} ‡
+-- Determine which set of colors to use.
+local _USE_HEX = go.termguicolors
+local _USE_256 = tonumber(go.t_Co) > 255
+	or string.find(vim.env.TERM, '256')
+
+--[[
+	/*
+	 * HELPER FUNCTIONS
+	 */
+--]]
 
 -- Add the 'blend' parameter to some highlight command, if there is one.
 local function blend(command, attributes) -- {{{ †
 	if attributes.blend then -- There is a value for the `highlight-blend` field.
-		command[#command + 1] = ' blend='..attributes.blend
+		command[#command+1]=' blend='..attributes.blend
+	end
+end --}}} ‡
+
+-- filter a highlight group's style information
+local function filter_group_style(value)
+	return value ~= 'background'
+		and value ~= 'blend'
+		and value ~= 'foreground'
+		and value ~= 'special'
+end
+
+-- Get the color value of a color variable, or "NONE" as a default.
+local function get(color, index) -- {{{ †
+	if type(color) == _TYPE_TABLE and color[index] then
+		return color[index]
+	elseif type(color) == _TYPE_STRING then
+		return color
+	else
+		return _NONE
 	end
 end --}}} ‡
 
 --[[ If using hex and 256-bit colors, then populate the gui* and cterm* args.
 	If using 16-bit colors, just populate the cterm* args. ]]
-local colorize = using_hex_or_256 and function(command, attributes) -- {{{ †
-	command[#command + 1] =
-		' ctermbg='..get(attributes.bg, PALETTE_256)
-		..' ctermfg='..get(attributes.fg, PALETTE_256)
-		..' guibg='..get(attributes.bg, PALETTE_HEX)
-		..' guifg='..get(attributes.fg, PALETTE_HEX)
-	blend(command, attributes)
+local colorize = _USE_HEX and function(command, attributes) -- {{{ †
+	command[#command+1]=' guibg='..get(attributes.bg, _PALETTE_HEX)..' guifg='..get(attributes.fg, _PALETTE_HEX)
+end or _USE_256 and function(command, attributes)
+	command[#command+1]=' ctermbg='..get(attributes.bg, _PALETTE_256)..' ctermfg='..get(attributes.fg, _PALETTE_256)
 end or function(command, attributes)
-	command[#command + 1] =
-		' ctermbg='..get(attributes.bg, PALETTE_ANSI)
-		..' ctermfg='..get(attributes.fg, PALETTE_ANSI)
-	blend(command, attributes)
+	command[#command+1]=' ctermbg='..get(attributes.bg, _PALETTE_ANSI)..' ctermfg='..get(attributes.fg, _PALETTE_ANSI)
 end --}}} ‡
 
 -- This function appends `selected_attributes` to the end of `highlight_cmd`.
-local stylize = using_hex_or_256 and function(command, style, color) -- {{{ †
-	command[#command + 1] = ' cterm='..style..' gui='..style
+local stylize = _USE_HEX and function(command, style, color)
+	command[#command+1]=' gui='..style
 
 	if color then -- There is an undercurl color.
-		command[#command + 1] = ' guisp='..get(color, PALETTE_HEX)
+		command[#command+1]=' guisp='..get(color, _PALETTE_HEX)
 	end
 end or function(command, style)
-	command[#command + 1] = ' cterm='..style
-end --}}} ‡
+	command[#command+1]=' cterm='..style
+end
+
+local function tohex(rgb) return string.format('#%06x', rgb) end
+
+-- Load specific &bg instructions
+local function use_background_with(attributes)
+	return setmetatable(
+		attributes[go.background],
+		{['__index'] = attributes}
+	)
+end
+
+--[[
+	/*
+	 * MODULE
+	 */
+--]]
+
+local highlite = {}
+
+function highlite.group(group_name)
+	local no_errors, group_definition = pcall(api.nvim_get_hl_by_name, group_name, go.termguicolors)
+
+	if not no_errors then group_definition = {} end
+
+	-- the style of the highlight group
+	local style = vim.tbl_filter(filter_group_style, vim.tbl_keys(group_definition))
+	if group_definition.special then
+		style.color = tohex(group_definition.special)
+	end
+
+	return {
+		['fg'] = group_definition.foreground and tohex(group_definition.foreground) or _NONE,
+		['bg'] = group_definition.background and tohex(group_definition.background) or _NONE,
+		['blend'] = group_definition.blend,
+		['style'] = style or _NONE
+	}
+end
 
 -- Generate a `:highlight` command from a group and some attributes.
-local function highlight(highlight_group, attributes) -- {{{ †
+function highlite.highlight(highlight_group, attributes) -- {{{ †
 	-- The base highlight command
 	local highlight_cmd = {'hi! ', highlight_group}
 
-	-- Take care of special instructions for certain background colors.
-	if attributes[vim.o.background] then
-		attributes.__index = attributes
-		attributes = setmetatable(attributes[vim.o.background], attributes)
-	end
-
-	-- Determine if there is a highlight link, and if so, assign it.
-	local link = (type(attributes) == 'string' and attributes)
-		or attributes.link
-
-	if link then -- `highlight_group` is a link to another group.
-		highlight_cmd[3] = highlight_cmd[2]..' '
+	if type(attributes) == _TYPE_STRING then -- `highlight_group` is a link to another group.
+		highlight_cmd[3] = highlight_cmd[2]
 		highlight_cmd[2] = 'link '
-		highlight_cmd[4] = link
+		highlight_cmd[4] = ' '
+		highlight_cmd[5] = attributes
 	else -- The `highlight_group` is uniquely defined.
-		colorize(highlight_cmd, attributes)
+		-- Take care of special instructions for certain background colors.
+		if attributes[go.background] then
+			attributes = use_background_with(attributes)
+		end
 
-		local style = attributes.style or NONE
-		if type(style) == 'table' then
+		colorize(highlight_cmd, attributes)
+		blend(highlight_cmd, attributes)
+
+		local style = attributes.style or _NONE
+
+		if type(style) == _TYPE_TABLE then
 			-- Concat all of the entries together with a comma between before styling.
 			stylize(highlight_cmd, table.concat(style, ','), style.color)
 		else -- The style is just a single entry.
@@ -101,15 +150,53 @@ local function highlight(highlight_group, attributes) -- {{{ †
 		end
 	end
 
-	vim.cmd(table.concat(highlight_cmd))
+	exe(table.concat(highlight_cmd))
 end --}}} ‡
 
-return function(Normal, highlights)
-	-- Highlight the baseline.
-	highlight('Normal', Normal)
-
-	-- Highlight everything else.
-	for highlight_group, attributes in pairs(highlights) do
-		highlight(highlight_group, attributes)
+function highlite:highlight_terminal(terminal_ansi_colors)
+	for index, color in ipairs(terminal_ansi_colors) do vim.g['terminal_color_'..(index-1)] =
+		go.termguicolors and color[_PALETTE_HEX] or color[_PALETTE_256] or get(color, _PALETTE_ANSI)
 	end
 end
+
+return setmetatable(highlite, {['__call'] = function(self, normal, highlights, terminal_ansi_colors)
+	-- function to resolve function highlight groups being defined by function calls.
+	local function resolve(tbl, key, resolve_links)
+		local value = tbl[key]
+		local value_type = type(value)
+		if value_type == 'function' then
+			-- lazily cache the result; next time, if it isn't a function this step will be skipped
+			tbl[key] = value(setmetatable({}, {
+				['__index'] = function(_, inner_key) return resolve(tbl, inner_key, true) end
+			}))
+		elseif value_type == _TYPE_STRING and not string.find(value, '^#') and resolve_links then
+			return resolve(tbl, tbl[key], resolve_links)
+		end
+
+		return tbl[key]
+	end
+
+	-- save the colors_name before syntax reset
+	local color_name = vim.g.colors_name
+
+	-- If the syntax has been enabled, reset it.
+	if fn.exists 'syntax_on' then exe 'syntax reset' end
+
+	-- replace the colors_name
+	vim.g.colors_name = color_name
+	color_name = nil
+
+	-- If we aren't using hex nor 256 colorsets.
+	if not (_USE_HEX or _USE_256) then go.t_Co = '16' end
+
+	-- Highlight the baseline.
+	self.highlight('Normal', normal)
+
+	-- Highlight everything else.
+	for highlight_group, _ in pairs(highlights) do
+		self.highlight(highlight_group, resolve(highlights, highlight_group, false))
+	end
+
+	-- Set the terminal highlight colors.
+	self:highlight_terminal(terminal_ansi_colors)
+end})


### PR DESCRIPTION
fixed #4 

Also, there is some existing issue. The order of the `termguicolors` setting and the `colorscheme` setting may play a role in whether the editor theme works properly.

```vim
"MUST set termguicolors first
set termguicolors
color deus
```

For more please read [Avimitin/neovim-deus](https://github.com/Avimitin/neovim-deus#known-issues) and [Color doesn't change after installed the plugin #11](https://github.com/Iron-E/nvim-highlite/issues/11)